### PR TITLE
mkcode now emmits Direction-information about positional parameters.

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -27,9 +27,9 @@ NTSTATUS NtDeleteAtom(
 /*
 func:
 NTSTATUS NtFindAtom(
-  _In_  PWCHAR    AtomName,
-  _In_  ULONG     Length,
-  _Out_ PRTL_ATOM Atom OPTIONAL );
+  _In_      PWCHAR    AtomName,
+  _In_      ULONG     Length,
+  _Out_opt_ PRTL_ATOM Atom);
 */
 
 /*

--- a/atom_generated.go
+++ b/atom_generated.go
@@ -34,8 +34,13 @@ type AtomTableInformationT struct {
 	Atoms         [1]RtlAtom
 }
 
-func NtAddAtom(AtomName *uint16, Length uint32, Atom *RtlAtom) NtStatus {
-	r0, _, _ := procNtAddAtom.Call(uintptr(unsafe.Pointer(AtomName)), uintptr(Length), uintptr(unsafe.Pointer(Atom)))
+// OUT-parameter: Atom.
+func NtAddAtom(AtomName *uint16,
+	Length uint32,
+	Atom *RtlAtom) NtStatus {
+	r0, _, _ := procNtAddAtom.Call(uintptr(unsafe.Pointer(AtomName)),
+		uintptr(Length),
+		uintptr(unsafe.Pointer(Atom)))
 	return NtStatus(r0)
 }
 
@@ -44,12 +49,27 @@ func NtDeleteAtom(Atom RtlAtom) NtStatus {
 	return NtStatus(r0)
 }
 
-func NtFindAtom(AtomName *uint16, Length uint32, OPTIONAL *RtlAtom) NtStatus {
-	r0, _, _ := procNtFindAtom.Call(uintptr(unsafe.Pointer(AtomName)), uintptr(Length), uintptr(unsafe.Pointer(OPTIONAL)))
+// OUT-parameter: Atom.
+// *OPT-parameter: Atom.
+func NtFindAtom(AtomName *uint16,
+	Length uint32,
+	Atom *RtlAtom) NtStatus {
+	r0, _, _ := procNtFindAtom.Call(uintptr(unsafe.Pointer(AtomName)),
+		uintptr(Length),
+		uintptr(unsafe.Pointer(Atom)))
 	return NtStatus(r0)
 }
 
-func NtQueryInformationAtom(Atom RtlAtom, AtomInformationClass AtomInformationClass, AtomInformation *byte, AtomInformationLength uint32, ReturnLength *uint32) NtStatus {
-	r0, _, _ := procNtQueryInformationAtom.Call(uintptr(Atom), uintptr(AtomInformationClass), uintptr(unsafe.Pointer(AtomInformation)), uintptr(AtomInformationLength), uintptr(unsafe.Pointer(ReturnLength)))
+// OUT-parameter: AtomInformation, ReturnLength.
+func NtQueryInformationAtom(Atom RtlAtom,
+	AtomInformationClass AtomInformationClass,
+	AtomInformation *byte,
+	AtomInformationLength uint32,
+	ReturnLength *uint32) NtStatus {
+	r0, _, _ := procNtQueryInformationAtom.Call(uintptr(Atom),
+		uintptr(AtomInformationClass),
+		uintptr(unsafe.Pointer(AtomInformation)),
+		uintptr(AtomInformationLength),
+		uintptr(unsafe.Pointer(ReturnLength)))
 	return NtStatus(r0)
 }

--- a/file_generated.go
+++ b/file_generated.go
@@ -432,32 +432,119 @@ type FileCompletionInformationT struct {
 	Key  *byte
 }
 
-func NtCreateFile(FileHandle *Handle, DesiredAccess AccessMask, ObjectAttributes *ObjectAttributes, IoStatusBlock *IoStatusBlock, AllocationSize *int64, FileAttributes uint32, ShareAccess uint32, CreateDisposition uint32, CreateOptions uint32, EaBuffer *byte, EaLength uint32) NtStatus {
-	r0, _, _ := procNtCreateFile.Call(uintptr(unsafe.Pointer(FileHandle)), uintptr(DesiredAccess), uintptr(unsafe.Pointer(ObjectAttributes)), uintptr(unsafe.Pointer(IoStatusBlock)), uintptr(unsafe.Pointer(AllocationSize)), uintptr(FileAttributes), uintptr(ShareAccess), uintptr(CreateDisposition), uintptr(CreateOptions), uintptr(unsafe.Pointer(EaBuffer)), uintptr(EaLength))
+// OUT-parameter: FileHandle, IoStatusBlock.
+// *OPT-parameter: AllocationSize.
+func NtCreateFile(FileHandle *Handle,
+	DesiredAccess AccessMask,
+	ObjectAttributes *ObjectAttributes,
+	IoStatusBlock *IoStatusBlock,
+	AllocationSize *int64,
+	FileAttributes uint32,
+	ShareAccess uint32,
+	CreateDisposition uint32,
+	CreateOptions uint32,
+	EaBuffer *byte,
+	EaLength uint32) NtStatus {
+	r0, _, _ := procNtCreateFile.Call(uintptr(unsafe.Pointer(FileHandle)),
+		uintptr(DesiredAccess),
+		uintptr(unsafe.Pointer(ObjectAttributes)),
+		uintptr(unsafe.Pointer(IoStatusBlock)),
+		uintptr(unsafe.Pointer(AllocationSize)),
+		uintptr(FileAttributes),
+		uintptr(ShareAccess),
+		uintptr(CreateDisposition),
+		uintptr(CreateOptions),
+		uintptr(unsafe.Pointer(EaBuffer)),
+		uintptr(EaLength))
 	return NtStatus(r0)
 }
 
-func NtOpenFile(FileHandle *Handle, DesiredAccess AccessMask, ObjectAttributes *ObjectAttributes, IoStatusBlock *IoStatusBlock, ShareAccess uint32, OpenOptions uint32) NtStatus {
-	r0, _, _ := procNtOpenFile.Call(uintptr(unsafe.Pointer(FileHandle)), uintptr(DesiredAccess), uintptr(unsafe.Pointer(ObjectAttributes)), uintptr(unsafe.Pointer(IoStatusBlock)), uintptr(ShareAccess), uintptr(OpenOptions))
+// OUT-parameter: FileHandle, IoStatusBlock.
+func NtOpenFile(FileHandle *Handle,
+	DesiredAccess AccessMask,
+	ObjectAttributes *ObjectAttributes,
+	IoStatusBlock *IoStatusBlock,
+	ShareAccess uint32,
+	OpenOptions uint32) NtStatus {
+	r0, _, _ := procNtOpenFile.Call(uintptr(unsafe.Pointer(FileHandle)),
+		uintptr(DesiredAccess),
+		uintptr(unsafe.Pointer(ObjectAttributes)),
+		uintptr(unsafe.Pointer(IoStatusBlock)),
+		uintptr(ShareAccess),
+		uintptr(OpenOptions))
 	return NtStatus(r0)
 }
 
-func NtQueryInformationFile(FileHandle Handle, IoStatusBlock *IoStatusBlock, FileInformation *byte, Length uint32, FileInformationClass FileInformationClass) NtStatus {
-	r0, _, _ := procNtQueryInformationFile.Call(uintptr(FileHandle), uintptr(unsafe.Pointer(IoStatusBlock)), uintptr(unsafe.Pointer(FileInformation)), uintptr(Length), uintptr(FileInformationClass))
+// OUT-parameter: IoStatusBlock, FileInformation.
+func NtQueryInformationFile(FileHandle Handle,
+	IoStatusBlock *IoStatusBlock,
+	FileInformation *byte,
+	Length uint32,
+	FileInformationClass FileInformationClass) NtStatus {
+	r0, _, _ := procNtQueryInformationFile.Call(uintptr(FileHandle),
+		uintptr(unsafe.Pointer(IoStatusBlock)),
+		uintptr(unsafe.Pointer(FileInformation)),
+		uintptr(Length),
+		uintptr(FileInformationClass))
 	return NtStatus(r0)
 }
 
-func NtReadFile(FileHandle Handle, Event Handle, ApcRoutine *IoApcRoutine, ApcContext *byte, IoStatusBlock *IoStatusBlock, Buffer *byte, Length uint32, ByteOffset *int64, Key *uint32) NtStatus {
-	r0, _, _ := procNtReadFile.Call(uintptr(FileHandle), uintptr(Event), uintptr(unsafe.Pointer(ApcRoutine)), uintptr(unsafe.Pointer(ApcContext)), uintptr(unsafe.Pointer(IoStatusBlock)), uintptr(unsafe.Pointer(Buffer)), uintptr(Length), uintptr(unsafe.Pointer(ByteOffset)), uintptr(unsafe.Pointer(Key)))
+// OUT-parameter: IoStatusBlock, Buffer.
+// *OPT-parameter: Event, ApcRoutine, ApcContext, ByteOffset, Key.
+func NtReadFile(FileHandle Handle,
+	Event Handle,
+	ApcRoutine *IoApcRoutine,
+	ApcContext *byte,
+	IoStatusBlock *IoStatusBlock,
+	Buffer *byte,
+	Length uint32,
+	ByteOffset *int64,
+	Key *uint32) NtStatus {
+	r0, _, _ := procNtReadFile.Call(uintptr(FileHandle),
+		uintptr(Event),
+		uintptr(unsafe.Pointer(ApcRoutine)),
+		uintptr(unsafe.Pointer(ApcContext)),
+		uintptr(unsafe.Pointer(IoStatusBlock)),
+		uintptr(unsafe.Pointer(Buffer)),
+		uintptr(Length),
+		uintptr(unsafe.Pointer(ByteOffset)),
+		uintptr(unsafe.Pointer(Key)))
 	return NtStatus(r0)
 }
 
-func NtSetInformationFile2(FileHandle Handle, IoStatusBlock *IoStatusBlock, FileInformation *byte, Length uint32, FileInformationClass FileInformationClass) NtStatus {
-	r0, _, _ := procNtSetInformationFile2.Call(uintptr(FileHandle), uintptr(unsafe.Pointer(IoStatusBlock)), uintptr(unsafe.Pointer(FileInformation)), uintptr(Length), uintptr(FileInformationClass))
+// OUT-parameter: IoStatusBlock.
+func NtSetInformationFile2(FileHandle Handle,
+	IoStatusBlock *IoStatusBlock,
+	FileInformation *byte,
+	Length uint32,
+	FileInformationClass FileInformationClass) NtStatus {
+	r0, _, _ := procNtSetInformationFile2.Call(uintptr(FileHandle),
+		uintptr(unsafe.Pointer(IoStatusBlock)),
+		uintptr(unsafe.Pointer(FileInformation)),
+		uintptr(Length),
+		uintptr(FileInformationClass))
 	return NtStatus(r0)
 }
 
-func NtWriteFile(FileHandle Handle, Event Handle, ApcRoutine *IoApcRoutine, ApcContext *byte, IoStatusBlock *IoStatusBlock, Buffer *byte, Length uint32, ByteOffset *int64, Key *uint32) NtStatus {
-	r0, _, _ := procNtWriteFile.Call(uintptr(FileHandle), uintptr(Event), uintptr(unsafe.Pointer(ApcRoutine)), uintptr(unsafe.Pointer(ApcContext)), uintptr(unsafe.Pointer(IoStatusBlock)), uintptr(unsafe.Pointer(Buffer)), uintptr(Length), uintptr(unsafe.Pointer(ByteOffset)), uintptr(unsafe.Pointer(Key)))
+// OUT-parameter: IoStatusBlock.
+// *OPT-parameter: Event, ApcRoutine, ApcContext, ByteOffset, Key.
+func NtWriteFile(FileHandle Handle,
+	Event Handle,
+	ApcRoutine *IoApcRoutine,
+	ApcContext *byte,
+	IoStatusBlock *IoStatusBlock,
+	Buffer *byte,
+	Length uint32,
+	ByteOffset *int64,
+	Key *uint32) NtStatus {
+	r0, _, _ := procNtWriteFile.Call(uintptr(FileHandle),
+		uintptr(Event),
+		uintptr(unsafe.Pointer(ApcRoutine)),
+		uintptr(unsafe.Pointer(ApcContext)),
+		uintptr(unsafe.Pointer(IoStatusBlock)),
+		uintptr(unsafe.Pointer(Buffer)),
+		uintptr(Length),
+		uintptr(unsafe.Pointer(ByteOffset)),
+		uintptr(unsafe.Pointer(Key)))
 	return NtStatus(r0)
 }

--- a/lsa_generated.go
+++ b/lsa_generated.go
@@ -13,23 +13,51 @@ var (
 	procLsaClose                  = modntdll.NewProc("LsaClose")
 )
 
-func LsaOpenPolicy(SystemName *LsaUnicodeString, ObjectAttributes *LsaObjectAttributes, DesiredAccess AccessMask, PolicyHandle *LsaHandle) NtStatus {
-	r0, _, _ := procLsaOpenPolicy.Call(uintptr(unsafe.Pointer(SystemName)), uintptr(unsafe.Pointer(ObjectAttributes)), uintptr(DesiredAccess), uintptr(unsafe.Pointer(PolicyHandle)))
+// INOUT-parameter: PolicyHandle.
+func LsaOpenPolicy(SystemName *LsaUnicodeString,
+	ObjectAttributes *LsaObjectAttributes,
+	DesiredAccess AccessMask,
+	PolicyHandle *LsaHandle) NtStatus {
+	r0, _, _ := procLsaOpenPolicy.Call(uintptr(unsafe.Pointer(SystemName)),
+		uintptr(unsafe.Pointer(ObjectAttributes)),
+		uintptr(DesiredAccess),
+		uintptr(unsafe.Pointer(PolicyHandle)))
 	return NtStatus(r0)
 }
 
-func LsaAddAccountRights(PolicyHandle LsaHandle, AccountSid *Sid, UserRights *LsaUnicodeString, CountOfRights uint32) NtStatus {
-	r0, _, _ := procLsaAddAccountRights.Call(uintptr(PolicyHandle), uintptr(unsafe.Pointer(AccountSid)), uintptr(unsafe.Pointer(UserRights)), uintptr(CountOfRights))
+func LsaAddAccountRights(PolicyHandle LsaHandle,
+	AccountSid *Sid,
+	UserRights *LsaUnicodeString,
+	CountOfRights uint32) NtStatus {
+	r0, _, _ := procLsaAddAccountRights.Call(uintptr(PolicyHandle),
+		uintptr(unsafe.Pointer(AccountSid)),
+		uintptr(unsafe.Pointer(UserRights)),
+		uintptr(CountOfRights))
 	return NtStatus(r0)
 }
 
-func LsaEnumerateAccountRights(PolicyHandle LsaHandle, AccountSid *Sid, UserRights *LsaUnicodeString, CountOfRights *uint32) NtStatus {
-	r0, _, _ := procLsaEnumerateAccountRights.Call(uintptr(PolicyHandle), uintptr(unsafe.Pointer(AccountSid)), uintptr(unsafe.Pointer(UserRights)), uintptr(unsafe.Pointer(CountOfRights)))
+// OUT-parameter: UserRights, CountOfRights.
+func LsaEnumerateAccountRights(PolicyHandle LsaHandle,
+	AccountSid *Sid,
+	UserRights *LsaUnicodeString,
+	CountOfRights *uint32) NtStatus {
+	r0, _, _ := procLsaEnumerateAccountRights.Call(uintptr(PolicyHandle),
+		uintptr(unsafe.Pointer(AccountSid)),
+		uintptr(unsafe.Pointer(UserRights)),
+		uintptr(unsafe.Pointer(CountOfRights)))
 	return NtStatus(r0)
 }
 
-func LsaRemoveAccountRights(PolicyHandle LsaHandle, AccountSid *Sid, AllRights bool, UserRights *LsaUnicodeString, CountOfRights uint32) NtStatus {
-	r0, _, _ := procLsaRemoveAccountRights.Call(uintptr(PolicyHandle), uintptr(unsafe.Pointer(AccountSid)), fromBool(AllRights), uintptr(unsafe.Pointer(UserRights)), uintptr(CountOfRights))
+func LsaRemoveAccountRights(PolicyHandle LsaHandle,
+	AccountSid *Sid,
+	AllRights bool,
+	UserRights *LsaUnicodeString,
+	CountOfRights uint32) NtStatus {
+	r0, _, _ := procLsaRemoveAccountRights.Call(uintptr(PolicyHandle),
+		uintptr(unsafe.Pointer(AccountSid)),
+		fromBool(AllRights),
+		uintptr(unsafe.Pointer(UserRights)),
+		uintptr(CountOfRights))
 	return NtStatus(r0)
 }
 

--- a/mkcode.go
+++ b/mkcode.go
@@ -43,8 +43,12 @@ type Direction int
 const (
 	DirectionUnspecified Direction = iota
 	DirectionIn
+	DirectionInOpt
 	DirectionOut
+	DirectionOutOpt
 	DirectionInOut
+	DirectionInOutOpt
+	DirectionReserved
 )
 
 type FunctionParameterDefinition struct {
@@ -185,17 +189,26 @@ func ParseFunctionDefinition(rd io.Reader) (*FunctionDefinition, error) {
 				if len(tokens) < 2 {
 					return nil, fmt.Errorf("function parameter needs at least a name and a type")
 				}
+
 				p := FunctionParameterDefinition{Name: tokens[0]}
+
 				var typ string
 				for _, t := range tokens[1:] {
 					switch t {
-					case "_In_", "_In_opt_":
+					case "_In_":
 						p.Direction = DirectionIn
-					case "_Out_", "_Out_opt_":
+					case "_In_opt_":
+						p.Direction = DirectionInOpt
+					case "_Out_":
 						p.Direction = DirectionOut
-					case "_Inout_", "_Inout_opt_":
+					case "_Out_opt_":
+						p.Direction = DirectionOutOpt
+					case "_Inout_":
 						p.Direction = DirectionInOut
+					case "_Inout_opt_":
+						p.Direction = DirectionInOutOpt
 					case "_Reserved_":
+						p.Direction = DirectionReserved
 					default:
 						typ = t
 					}
@@ -561,7 +574,28 @@ type %[1]s struct {
 
 	for _, function := range functions {
 		var plist, alist []string
+		var out, inout, opt, reserved, unknown []string
+		var comment string
 		for _, param := range function.Params {
+			switch param.Direction {
+			case DirectionIn: // default, don't mention
+			case DirectionInOpt:
+				opt = append(opt, param.Name)
+			case DirectionOut:
+				out = append(out, param.Name)
+			case DirectionOutOpt:
+				out = append(out, param.Name)
+				opt = append(opt, param.Name)
+			case DirectionInOut:
+				inout = append(inout, param.Name)
+			case DirectionInOutOpt:
+				inout = append(inout, param.Name)
+				opt = append(opt, param.Name)
+			case DirectionReserved:
+				reserved = append(reserved, param.Name)
+			default:
+				unknown = append(unknown, param.Name)
+			}
 			alist = append(alist, fmt.Sprintf("%s %s", param.Name, param.Type))
 			if param.Type == "bool" {
 				plist = append(plist, fmt.Sprintf("fromBool(%s)", param.Name))
@@ -573,16 +607,32 @@ type %[1]s struct {
 			// alist = append(alist, fmt.Sprintf("p%d %s", n, param.Type))
 			// plist = append(plist, "p"+strconv.Itoa(n))
 		}
+		if len(out) > 0 {
+			comment = fmt.Sprintf("// OUT-parameter: %s.\n", strings.Join(out, ", "))
+		}
+		if len(inout) > 0 {
+			comment += fmt.Sprintf("// INOUT-parameter: %s.\n", strings.Join(inout, ", "))
+		}
+		if len(reserved) > 0 {
+			comment += fmt.Sprintf("// RESERVED-parameter: %s.\n", strings.Join(reserved, ", "))
+		}
+		if len(opt) > 0 {
+			comment += fmt.Sprintf("// *OPT-parameter: %s.\n", strings.Join(opt, ", "))
+		}
+		if len(unknown) > 0 {
+			comment += fmt.Sprintf("// unknown-parameter: %s.\n", strings.Join(unknown, ", "))
+		}
+
 		returnExpression := function.Type + "(r0)"
 		if function.Type == "bool" {
 			returnExpression = "r0 != 0"
 		}
-		fmt.Fprintf(buf, `func %[1]s(%[2]s) %[3]s {
+		fmt.Fprintf(buf, `%[6]sfunc %[1]s(%[2]s) %[3]s {
 	r0, _, _ := proc%[1]s.Call(%[4]s)
 	return %[5]s
 }
 
-`, function.Name, strings.Join(alist, ", "), function.Type, strings.Join(plist, ", "), returnExpression)
+`, function.Name, strings.Join(alist, ",\n"), function.Type, strings.Join(plist, ",\n"), returnExpression, comment)
 	}
 
 	f, err = os.Create(outfile)

--- a/object_generated.go
+++ b/object_generated.go
@@ -30,32 +30,76 @@ type ObjectDirectoryInformationT struct {
 	TypeName UnicodeString
 }
 
-func NtOpenDirectoryObject(DirectoryHandle *Handle, DesiredAccess AccessMask, ObjectAttributes *ObjectAttributes) NtStatus {
-	r0, _, _ := procNtOpenDirectoryObject.Call(uintptr(unsafe.Pointer(DirectoryHandle)), uintptr(DesiredAccess), uintptr(unsafe.Pointer(ObjectAttributes)))
+// OUT-parameter: DirectoryHandle.
+func NtOpenDirectoryObject(DirectoryHandle *Handle,
+	DesiredAccess AccessMask,
+	ObjectAttributes *ObjectAttributes) NtStatus {
+	r0, _, _ := procNtOpenDirectoryObject.Call(uintptr(unsafe.Pointer(DirectoryHandle)),
+		uintptr(DesiredAccess),
+		uintptr(unsafe.Pointer(ObjectAttributes)))
 	return NtStatus(r0)
 }
 
-func NtQueryDirectoryObject(DirectoryHandle Handle, Buffer *byte, Length uint32, ReturnSingleEntry bool, RestartScan bool, Context *uint32, ReturnLength *uint32) NtStatus {
-	r0, _, _ := procNtQueryDirectoryObject.Call(uintptr(DirectoryHandle), uintptr(unsafe.Pointer(Buffer)), uintptr(Length), fromBool(ReturnSingleEntry), fromBool(RestartScan), uintptr(unsafe.Pointer(Context)), uintptr(unsafe.Pointer(ReturnLength)))
+// OUT-parameter: Buffer, ReturnLength.
+// INOUT-parameter: Context.
+// *OPT-parameter: Buffer, ReturnLength.
+func NtQueryDirectoryObject(DirectoryHandle Handle,
+	Buffer *byte,
+	Length uint32,
+	ReturnSingleEntry bool,
+	RestartScan bool,
+	Context *uint32,
+	ReturnLength *uint32) NtStatus {
+	r0, _, _ := procNtQueryDirectoryObject.Call(uintptr(DirectoryHandle),
+		uintptr(unsafe.Pointer(Buffer)),
+		uintptr(Length),
+		fromBool(ReturnSingleEntry),
+		fromBool(RestartScan),
+		uintptr(unsafe.Pointer(Context)),
+		uintptr(unsafe.Pointer(ReturnLength)))
 	return NtStatus(r0)
 }
 
-func NtOpenSymbolicLinkObject(LinkHandle *Handle, DesiredAccess AccessMask, ObjectAttributes *ObjectAttributes) NtStatus {
-	r0, _, _ := procNtOpenSymbolicLinkObject.Call(uintptr(unsafe.Pointer(LinkHandle)), uintptr(DesiredAccess), uintptr(unsafe.Pointer(ObjectAttributes)))
+// OUT-parameter: LinkHandle.
+func NtOpenSymbolicLinkObject(LinkHandle *Handle,
+	DesiredAccess AccessMask,
+	ObjectAttributes *ObjectAttributes) NtStatus {
+	r0, _, _ := procNtOpenSymbolicLinkObject.Call(uintptr(unsafe.Pointer(LinkHandle)),
+		uintptr(DesiredAccess),
+		uintptr(unsafe.Pointer(ObjectAttributes)))
 	return NtStatus(r0)
 }
 
-func NtQuerySymbolicLinkObject(LinkHandle Handle, LinkTarget *UnicodeString, ReturnedLength *uint32) NtStatus {
-	r0, _, _ := procNtQuerySymbolicLinkObject.Call(uintptr(LinkHandle), uintptr(unsafe.Pointer(LinkTarget)), uintptr(unsafe.Pointer(ReturnedLength)))
+// OUT-parameter: ReturnedLength.
+// INOUT-parameter: LinkTarget.
+// *OPT-parameter: ReturnedLength.
+func NtQuerySymbolicLinkObject(LinkHandle Handle,
+	LinkTarget *UnicodeString,
+	ReturnedLength *uint32) NtStatus {
+	r0, _, _ := procNtQuerySymbolicLinkObject.Call(uintptr(LinkHandle),
+		uintptr(unsafe.Pointer(LinkTarget)),
+		uintptr(unsafe.Pointer(ReturnedLength)))
 	return NtStatus(r0)
 }
 
-func NtCreateSymbolicLinkObject(SymbolicLinkHandle *Handle, DesiredAccess AccessMask, ObjectAttributes *ObjectAttributes, TargetName *UnicodeString) NtStatus {
-	r0, _, _ := procNtCreateSymbolicLinkObject.Call(uintptr(unsafe.Pointer(SymbolicLinkHandle)), uintptr(DesiredAccess), uintptr(unsafe.Pointer(ObjectAttributes)), uintptr(unsafe.Pointer(TargetName)))
+// OUT-parameter: SymbolicLinkHandle.
+func NtCreateSymbolicLinkObject(SymbolicLinkHandle *Handle,
+	DesiredAccess AccessMask,
+	ObjectAttributes *ObjectAttributes,
+	TargetName *UnicodeString) NtStatus {
+	r0, _, _ := procNtCreateSymbolicLinkObject.Call(uintptr(unsafe.Pointer(SymbolicLinkHandle)),
+		uintptr(DesiredAccess),
+		uintptr(unsafe.Pointer(ObjectAttributes)),
+		uintptr(unsafe.Pointer(TargetName)))
 	return NtStatus(r0)
 }
 
-func NtCreateDirectoryObject(DirectoryHandle *Handle, DesiredAccess AccessMask, ObjectAttributes *ObjectAttributes) NtStatus {
-	r0, _, _ := procNtCreateDirectoryObject.Call(uintptr(unsafe.Pointer(DirectoryHandle)), uintptr(DesiredAccess), uintptr(unsafe.Pointer(ObjectAttributes)))
+// OUT-parameter: DirectoryHandle.
+func NtCreateDirectoryObject(DirectoryHandle *Handle,
+	DesiredAccess AccessMask,
+	ObjectAttributes *ObjectAttributes) NtStatus {
+	r0, _, _ := procNtCreateDirectoryObject.Call(uintptr(unsafe.Pointer(DirectoryHandle)),
+		uintptr(DesiredAccess),
+		uintptr(unsafe.Pointer(ObjectAttributes)))
 	return NtStatus(r0)
 }

--- a/registry_generated.go
+++ b/registry_generated.go
@@ -151,13 +151,45 @@ type KeyValuePartialInformationT struct {
 	Data       [1]byte
 }
 
-func NtCreateKey(KeyHandle *Handle, DesiredAccess AccessMask, ObjectAttributes *ObjectAttributes, TitleIndex uint32, Class *UnicodeString, CreateOptions uint32, Disposition *uint32) NtStatus {
-	r0, _, _ := procNtCreateKey.Call(uintptr(unsafe.Pointer(KeyHandle)), uintptr(DesiredAccess), uintptr(unsafe.Pointer(ObjectAttributes)), uintptr(TitleIndex), uintptr(unsafe.Pointer(Class)), uintptr(CreateOptions), uintptr(unsafe.Pointer(Disposition)))
+// OUT-parameter: KeyHandle, Disposition.
+// RESERVED-parameter: TitleIndex.
+// *OPT-parameter: Class, Disposition.
+func NtCreateKey(KeyHandle *Handle,
+	DesiredAccess AccessMask,
+	ObjectAttributes *ObjectAttributes,
+	TitleIndex uint32,
+	Class *UnicodeString,
+	CreateOptions uint32,
+	Disposition *uint32) NtStatus {
+	r0, _, _ := procNtCreateKey.Call(uintptr(unsafe.Pointer(KeyHandle)),
+		uintptr(DesiredAccess),
+		uintptr(unsafe.Pointer(ObjectAttributes)),
+		uintptr(TitleIndex),
+		uintptr(unsafe.Pointer(Class)),
+		uintptr(CreateOptions),
+		uintptr(unsafe.Pointer(Disposition)))
 	return NtStatus(r0)
 }
 
-func NtCreateKeyTransacted(KeyHandle *Handle, DesiredAccess AccessMask, ObjectAttributes *ObjectAttributes, TitleIndex uint32, Class *UnicodeString, CreateOptions uint32, TransactionHandle Handle, Disposition *uint32) NtStatus {
-	r0, _, _ := procNtCreateKeyTransacted.Call(uintptr(unsafe.Pointer(KeyHandle)), uintptr(DesiredAccess), uintptr(unsafe.Pointer(ObjectAttributes)), uintptr(TitleIndex), uintptr(unsafe.Pointer(Class)), uintptr(CreateOptions), uintptr(TransactionHandle), uintptr(unsafe.Pointer(Disposition)))
+// OUT-parameter: KeyHandle, Disposition.
+// RESERVED-parameter: TitleIndex.
+// *OPT-parameter: Class, Disposition.
+func NtCreateKeyTransacted(KeyHandle *Handle,
+	DesiredAccess AccessMask,
+	ObjectAttributes *ObjectAttributes,
+	TitleIndex uint32,
+	Class *UnicodeString,
+	CreateOptions uint32,
+	TransactionHandle Handle,
+	Disposition *uint32) NtStatus {
+	r0, _, _ := procNtCreateKeyTransacted.Call(uintptr(unsafe.Pointer(KeyHandle)),
+		uintptr(DesiredAccess),
+		uintptr(unsafe.Pointer(ObjectAttributes)),
+		uintptr(TitleIndex),
+		uintptr(unsafe.Pointer(Class)),
+		uintptr(CreateOptions),
+		uintptr(TransactionHandle),
+		uintptr(unsafe.Pointer(Disposition)))
 	return NtStatus(r0)
 }
 
@@ -166,18 +198,44 @@ func NtDeleteKey(KeyHandle Handle) NtStatus {
 	return NtStatus(r0)
 }
 
-func NtDeleteValueKey(KeyHandle Handle, ValueName *UnicodeString) NtStatus {
-	r0, _, _ := procNtDeleteValueKey.Call(uintptr(KeyHandle), uintptr(unsafe.Pointer(ValueName)))
+func NtDeleteValueKey(KeyHandle Handle,
+	ValueName *UnicodeString) NtStatus {
+	r0, _, _ := procNtDeleteValueKey.Call(uintptr(KeyHandle),
+		uintptr(unsafe.Pointer(ValueName)))
 	return NtStatus(r0)
 }
 
-func NtEnumerateKey(KeyHandle Handle, Index uint32, KeyInformationClass KeyInformationClass, KeyInformation *byte, Length uint32, ResultLength *uint32) NtStatus {
-	r0, _, _ := procNtEnumerateKey.Call(uintptr(KeyHandle), uintptr(Index), uintptr(KeyInformationClass), uintptr(unsafe.Pointer(KeyInformation)), uintptr(Length), uintptr(unsafe.Pointer(ResultLength)))
+// OUT-parameter: KeyInformation, ResultLength.
+// *OPT-parameter: KeyInformation.
+func NtEnumerateKey(KeyHandle Handle,
+	Index uint32,
+	KeyInformationClass KeyInformationClass,
+	KeyInformation *byte,
+	Length uint32,
+	ResultLength *uint32) NtStatus {
+	r0, _, _ := procNtEnumerateKey.Call(uintptr(KeyHandle),
+		uintptr(Index),
+		uintptr(KeyInformationClass),
+		uintptr(unsafe.Pointer(KeyInformation)),
+		uintptr(Length),
+		uintptr(unsafe.Pointer(ResultLength)))
 	return NtStatus(r0)
 }
 
-func NtEnumerateValueKey(KeyHandle Handle, Index uint32, KeyValueInformationClass KeyValueInformationClass, KeyValueInformation *byte, Length uint32, ResultLength *uint32) NtStatus {
-	r0, _, _ := procNtEnumerateValueKey.Call(uintptr(KeyHandle), uintptr(Index), uintptr(KeyValueInformationClass), uintptr(unsafe.Pointer(KeyValueInformation)), uintptr(Length), uintptr(unsafe.Pointer(ResultLength)))
+// OUT-parameter: KeyValueInformation, ResultLength.
+// *OPT-parameter: KeyValueInformation.
+func NtEnumerateValueKey(KeyHandle Handle,
+	Index uint32,
+	KeyValueInformationClass KeyValueInformationClass,
+	KeyValueInformation *byte,
+	Length uint32,
+	ResultLength *uint32) NtStatus {
+	r0, _, _ := procNtEnumerateValueKey.Call(uintptr(KeyHandle),
+		uintptr(Index),
+		uintptr(KeyValueInformationClass),
+		uintptr(unsafe.Pointer(KeyValueInformation)),
+		uintptr(Length),
+		uintptr(unsafe.Pointer(ResultLength)))
 	return NtStatus(r0)
 }
 
@@ -186,57 +244,176 @@ func NtFlushKey(KeyHandle Handle) NtStatus {
 	return NtStatus(r0)
 }
 
-func NtNotifyChangeKey(KeyHandle Handle, Event Handle, ApcRoutine *IoApcRoutine, ApcContext *byte, IoStatusBlock *IoStatusBlock, CompletionFilter uint32, WatchTree bool, Buffer *byte, BufferSize uint32, Asynchronous bool) NtStatus {
-	r0, _, _ := procNtNotifyChangeKey.Call(uintptr(KeyHandle), uintptr(Event), uintptr(unsafe.Pointer(ApcRoutine)), uintptr(unsafe.Pointer(ApcContext)), uintptr(unsafe.Pointer(IoStatusBlock)), uintptr(CompletionFilter), fromBool(WatchTree), uintptr(unsafe.Pointer(Buffer)), uintptr(BufferSize), fromBool(Asynchronous))
+// OUT-parameter: IoStatusBlock, Buffer.
+// *OPT-parameter: Event, ApcRoutine, ApcContext, Buffer.
+func NtNotifyChangeKey(KeyHandle Handle,
+	Event Handle,
+	ApcRoutine *IoApcRoutine,
+	ApcContext *byte,
+	IoStatusBlock *IoStatusBlock,
+	CompletionFilter uint32,
+	WatchTree bool,
+	Buffer *byte,
+	BufferSize uint32,
+	Asynchronous bool) NtStatus {
+	r0, _, _ := procNtNotifyChangeKey.Call(uintptr(KeyHandle),
+		uintptr(Event),
+		uintptr(unsafe.Pointer(ApcRoutine)),
+		uintptr(unsafe.Pointer(ApcContext)),
+		uintptr(unsafe.Pointer(IoStatusBlock)),
+		uintptr(CompletionFilter),
+		fromBool(WatchTree),
+		uintptr(unsafe.Pointer(Buffer)),
+		uintptr(BufferSize),
+		fromBool(Asynchronous))
 	return NtStatus(r0)
 }
 
-func NtNotifyChangeMultipleKeys(MasterKeyHandle Handle, Count uint32, SubordinateObjects *ObjectAttributes, Event Handle, ApcRoutine *IoApcRoutine, ApcContext *byte, IoStatusBlock *IoStatusBlock, CompletionFilter uint32, WatchTree bool, Buffer *byte, BufferSize uint32, Asynchronous bool) NtStatus {
-	r0, _, _ := procNtNotifyChangeMultipleKeys.Call(uintptr(MasterKeyHandle), uintptr(Count), uintptr(unsafe.Pointer(SubordinateObjects)), uintptr(Event), uintptr(unsafe.Pointer(ApcRoutine)), uintptr(unsafe.Pointer(ApcContext)), uintptr(unsafe.Pointer(IoStatusBlock)), uintptr(CompletionFilter), fromBool(WatchTree), uintptr(unsafe.Pointer(Buffer)), uintptr(BufferSize), fromBool(Asynchronous))
+// OUT-parameter: IoStatusBlock, Buffer.
+// *OPT-parameter: Count, SubordinateObjects, Event, ApcRoutine, ApcContext, Buffer.
+func NtNotifyChangeMultipleKeys(MasterKeyHandle Handle,
+	Count uint32,
+	SubordinateObjects *ObjectAttributes,
+	Event Handle,
+	ApcRoutine *IoApcRoutine,
+	ApcContext *byte,
+	IoStatusBlock *IoStatusBlock,
+	CompletionFilter uint32,
+	WatchTree bool,
+	Buffer *byte,
+	BufferSize uint32,
+	Asynchronous bool) NtStatus {
+	r0, _, _ := procNtNotifyChangeMultipleKeys.Call(uintptr(MasterKeyHandle),
+		uintptr(Count),
+		uintptr(unsafe.Pointer(SubordinateObjects)),
+		uintptr(Event),
+		uintptr(unsafe.Pointer(ApcRoutine)),
+		uintptr(unsafe.Pointer(ApcContext)),
+		uintptr(unsafe.Pointer(IoStatusBlock)),
+		uintptr(CompletionFilter),
+		fromBool(WatchTree),
+		uintptr(unsafe.Pointer(Buffer)),
+		uintptr(BufferSize),
+		fromBool(Asynchronous))
 	return NtStatus(r0)
 }
 
-func NtOpenKey(KeyHandle *Handle, DesiredAccess AccessMask, ObjectAttributes *ObjectAttributes) NtStatus {
-	r0, _, _ := procNtOpenKey.Call(uintptr(unsafe.Pointer(KeyHandle)), uintptr(DesiredAccess), uintptr(unsafe.Pointer(ObjectAttributes)))
+// OUT-parameter: KeyHandle.
+func NtOpenKey(KeyHandle *Handle,
+	DesiredAccess AccessMask,
+	ObjectAttributes *ObjectAttributes) NtStatus {
+	r0, _, _ := procNtOpenKey.Call(uintptr(unsafe.Pointer(KeyHandle)),
+		uintptr(DesiredAccess),
+		uintptr(unsafe.Pointer(ObjectAttributes)))
 	return NtStatus(r0)
 }
 
-func NtOpenKeyTransacted(KeyHandle *Handle, DesiredAccess AccessMask, ObjectAttributes *ObjectAttributes, TransactionHandle Handle) NtStatus {
-	r0, _, _ := procNtOpenKeyTransacted.Call(uintptr(unsafe.Pointer(KeyHandle)), uintptr(DesiredAccess), uintptr(unsafe.Pointer(ObjectAttributes)), uintptr(TransactionHandle))
+// OUT-parameter: KeyHandle.
+func NtOpenKeyTransacted(KeyHandle *Handle,
+	DesiredAccess AccessMask,
+	ObjectAttributes *ObjectAttributes,
+	TransactionHandle Handle) NtStatus {
+	r0, _, _ := procNtOpenKeyTransacted.Call(uintptr(unsafe.Pointer(KeyHandle)),
+		uintptr(DesiredAccess),
+		uintptr(unsafe.Pointer(ObjectAttributes)),
+		uintptr(TransactionHandle))
 	return NtStatus(r0)
 }
 
-func NtOpenKeyTransactedEx(KeyHandle *Handle, DesiredAccess AccessMask, ObjectAttributes *ObjectAttributes, OpenOptions uint32, TransactionHandle Handle) NtStatus {
-	r0, _, _ := procNtOpenKeyTransactedEx.Call(uintptr(unsafe.Pointer(KeyHandle)), uintptr(DesiredAccess), uintptr(unsafe.Pointer(ObjectAttributes)), uintptr(OpenOptions), uintptr(TransactionHandle))
+// OUT-parameter: KeyHandle.
+func NtOpenKeyTransactedEx(KeyHandle *Handle,
+	DesiredAccess AccessMask,
+	ObjectAttributes *ObjectAttributes,
+	OpenOptions uint32,
+	TransactionHandle Handle) NtStatus {
+	r0, _, _ := procNtOpenKeyTransactedEx.Call(uintptr(unsafe.Pointer(KeyHandle)),
+		uintptr(DesiredAccess),
+		uintptr(unsafe.Pointer(ObjectAttributes)),
+		uintptr(OpenOptions),
+		uintptr(TransactionHandle))
 	return NtStatus(r0)
 }
 
-func NtQueryKey(KeyHandle Handle, KeyInformationClass KeyInformationClass, KeyInformation *byte, Length uint32, ResultLength *uint32) NtStatus {
-	r0, _, _ := procNtQueryKey.Call(uintptr(KeyHandle), uintptr(KeyInformationClass), uintptr(unsafe.Pointer(KeyInformation)), uintptr(Length), uintptr(unsafe.Pointer(ResultLength)))
+// OUT-parameter: KeyInformation, ResultLength.
+// *OPT-parameter: KeyInformation.
+func NtQueryKey(KeyHandle Handle,
+	KeyInformationClass KeyInformationClass,
+	KeyInformation *byte,
+	Length uint32,
+	ResultLength *uint32) NtStatus {
+	r0, _, _ := procNtQueryKey.Call(uintptr(KeyHandle),
+		uintptr(KeyInformationClass),
+		uintptr(unsafe.Pointer(KeyInformation)),
+		uintptr(Length),
+		uintptr(unsafe.Pointer(ResultLength)))
 	return NtStatus(r0)
 }
 
-func NtQueryMultipleValueKey(KeyHandle Handle, ValueEntries *KeyValueEntry, EntryCount uint32, ValueBuffer *byte, BufferLength *uint32, RequiredBufferLength *uint32) NtStatus {
-	r0, _, _ := procNtQueryMultipleValueKey.Call(uintptr(KeyHandle), uintptr(unsafe.Pointer(ValueEntries)), uintptr(EntryCount), uintptr(unsafe.Pointer(ValueBuffer)), uintptr(unsafe.Pointer(BufferLength)), uintptr(unsafe.Pointer(RequiredBufferLength)))
+// OUT-parameter: ValueBuffer, RequiredBufferLength.
+// INOUT-parameter: ValueEntries, BufferLength.
+// *OPT-parameter: RequiredBufferLength.
+func NtQueryMultipleValueKey(KeyHandle Handle,
+	ValueEntries *KeyValueEntry,
+	EntryCount uint32,
+	ValueBuffer *byte,
+	BufferLength *uint32,
+	RequiredBufferLength *uint32) NtStatus {
+	r0, _, _ := procNtQueryMultipleValueKey.Call(uintptr(KeyHandle),
+		uintptr(unsafe.Pointer(ValueEntries)),
+		uintptr(EntryCount),
+		uintptr(unsafe.Pointer(ValueBuffer)),
+		uintptr(unsafe.Pointer(BufferLength)),
+		uintptr(unsafe.Pointer(RequiredBufferLength)))
 	return NtStatus(r0)
 }
 
-func NtQueryValueKey(KeyHandle Handle, ValueName *UnicodeString, KeyValueInformationClass KeyValueInformationClass, KeyValueInformation *byte, Length uint32, ResultLength *uint32) NtStatus {
-	r0, _, _ := procNtQueryValueKey.Call(uintptr(KeyHandle), uintptr(unsafe.Pointer(ValueName)), uintptr(KeyValueInformationClass), uintptr(unsafe.Pointer(KeyValueInformation)), uintptr(Length), uintptr(unsafe.Pointer(ResultLength)))
+// OUT-parameter: KeyValueInformation, ResultLength.
+// *OPT-parameter: KeyValueInformation.
+func NtQueryValueKey(KeyHandle Handle,
+	ValueName *UnicodeString,
+	KeyValueInformationClass KeyValueInformationClass,
+	KeyValueInformation *byte,
+	Length uint32,
+	ResultLength *uint32) NtStatus {
+	r0, _, _ := procNtQueryValueKey.Call(uintptr(KeyHandle),
+		uintptr(unsafe.Pointer(ValueName)),
+		uintptr(KeyValueInformationClass),
+		uintptr(unsafe.Pointer(KeyValueInformation)),
+		uintptr(Length),
+		uintptr(unsafe.Pointer(ResultLength)))
 	return NtStatus(r0)
 }
 
-func NtRenameKey(KeyHandle Handle, NewName *UnicodeString) NtStatus {
-	r0, _, _ := procNtRenameKey.Call(uintptr(KeyHandle), uintptr(unsafe.Pointer(NewName)))
+func NtRenameKey(KeyHandle Handle,
+	NewName *UnicodeString) NtStatus {
+	r0, _, _ := procNtRenameKey.Call(uintptr(KeyHandle),
+		uintptr(unsafe.Pointer(NewName)))
 	return NtStatus(r0)
 }
 
-func NtSetInformationKey(KeyHandle Handle, KeySetInformationClass KeySetInformationClass, KeySetInformation *byte, KeySetInformationLength uint32) NtStatus {
-	r0, _, _ := procNtSetInformationKey.Call(uintptr(KeyHandle), uintptr(KeySetInformationClass), uintptr(unsafe.Pointer(KeySetInformation)), uintptr(KeySetInformationLength))
+func NtSetInformationKey(KeyHandle Handle,
+	KeySetInformationClass KeySetInformationClass,
+	KeySetInformation *byte,
+	KeySetInformationLength uint32) NtStatus {
+	r0, _, _ := procNtSetInformationKey.Call(uintptr(KeyHandle),
+		uintptr(KeySetInformationClass),
+		uintptr(unsafe.Pointer(KeySetInformation)),
+		uintptr(KeySetInformationLength))
 	return NtStatus(r0)
 }
 
-func NtSetValueKey(KeyHandle Handle, ValueName *UnicodeString, TitleIndex uint32, Type uint32, Data *byte, DataSize uint32) NtStatus {
-	r0, _, _ := procNtSetValueKey.Call(uintptr(KeyHandle), uintptr(unsafe.Pointer(ValueName)), uintptr(TitleIndex), uintptr(Type), uintptr(unsafe.Pointer(Data)), uintptr(DataSize))
+// *OPT-parameter: TitleIndex, Data.
+func NtSetValueKey(KeyHandle Handle,
+	ValueName *UnicodeString,
+	TitleIndex uint32,
+	Type uint32,
+	Data *byte,
+	DataSize uint32) NtStatus {
+	r0, _, _ := procNtSetValueKey.Call(uintptr(KeyHandle),
+		uintptr(unsafe.Pointer(ValueName)),
+		uintptr(TitleIndex),
+		uintptr(Type),
+		uintptr(unsafe.Pointer(Data)),
+		uintptr(DataSize))
 	return NtStatus(r0)
 }

--- a/rtl_generated.go
+++ b/rtl_generated.go
@@ -22,7 +22,15 @@ type RtlpCurdirRef struct {
 	Handle   Handle
 }
 
-func RtlDosPathNameToNtPathName_U(DosFileName *uint16, NtFileName *UnicodeString, FilePart *uint16, RelativeName *RtlRelativeNameU) bool {
-	r0, _, _ := procRtlDosPathNameToNtPathName_U.Call(uintptr(unsafe.Pointer(DosFileName)), uintptr(unsafe.Pointer(NtFileName)), uintptr(unsafe.Pointer(FilePart)), uintptr(unsafe.Pointer(RelativeName)))
+// OUT-parameter: NtFileName, FilePart, RelativeName.
+// *OPT-parameter: FilePart, RelativeName.
+func RtlDosPathNameToNtPathName_U(DosFileName *uint16,
+	NtFileName *UnicodeString,
+	FilePart *uint16,
+	RelativeName *RtlRelativeNameU) bool {
+	r0, _, _ := procRtlDosPathNameToNtPathName_U.Call(uintptr(unsafe.Pointer(DosFileName)),
+		uintptr(unsafe.Pointer(NtFileName)),
+		uintptr(unsafe.Pointer(FilePart)),
+		uintptr(unsafe.Pointer(RelativeName)))
 	return r0 != 0
 }


### PR DESCRIPTION
Hi,

I adapted mkcode.go to use the direction-information that was already extracted (`_In_`, `_Out_`, `_InOpt_`, etc.) and put it as comments before a func-declaration.  That way, a call to `go doc ...` reveals that information about the positional parameters, f.e.:

     % go doc oec/go-ntdll.NtQueryDirectoryObject
     package ntdll // import "github.com/oec/go-ntdll"
     
     func NtQueryDirectoryObject(DirectoryHandle Handle,
             Buffer *byte,
             Length uint32,
             ReturnSingleEntry bool,
             RestartScan bool,
             Context *uint32,
             ReturnLength *uint32) NtStatus
         OUT-parameter: Buffer, ReturnLength. INOUT-parameter: Context.
        *OPT-parameter: Buffer, ReturnLength.

The positional parameters are also printed with newlines to increase readability.

And, after reading some signatures on http://ntinternals.net, I also removed a leftover `OPTIONAL` in atom.go and changed the corresponding variable into an `_Out_opt_`.

Cheers,
Özgür

[ps: this is a cleaned-up version of the previous PR]