### PR TITLE
Removing unused process and thread constants

### DIFF
--- a/process.go
+++ b/process.go
@@ -251,8 +251,3 @@ const (
 	THREAD_SET_LIMITED_INFORMATION   = 0x0400
 	THREAD_QUERY_LIMITED_INFORMATION = 0x0800
 )
-
-const (
-	NtCurrentProcess = Handle(0xffffffffffffffff)
-	NtCurrentThread  = Handle(0xfffffffffffffffe)
-)


### PR DESCRIPTION
Constants `NtCurrentProcess` and `NtCurrentThread` lead to compile time errors (overflow warning) when building for 32-bit architecture.  As they are unused, I'd like to propose to remove them.